### PR TITLE
Update req-info library for keycloak-gatekeeper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lev-restify",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Life Event Verification's Restify Server",
   "main": "src/index.js",
   "scripts": {

--- a/src/lib/req-info.js
+++ b/src/lib/req-info.js
@@ -1,8 +1,13 @@
 'use strict';
 
-module.exports = (req) => ({
-  username: req.headers['x-auth-username'],
-  client: req.headers['x-auth-aud'],
-  groups: req.headers['x-auth-groups'] && String(req.headers['x-auth-groups']).split(',') || [],
-  roles: req.headers['x-auth-roles'] && String(req.headers['x-auth-roles']).split(',') || []
-});
+module.exports = (req) => {
+  const aud = req.headers['x-auth-aud'] || req.headers['x-auth-audience'];
+  const client = aud && aud.split(',').filter(e => e !== 'lev-api')[0];
+
+  return ({
+    username: req.headers['x-auth-username'],
+    client: client,
+    groups: req.headers['x-auth-groups'] && String(req.headers['x-auth-groups']).split(',') || [],
+    roles: req.headers['x-auth-roles'] && String(req.headers['x-auth-roles']).split(',') || []
+  });
+};

--- a/test/unit/lib/req-info.js
+++ b/test/unit/lib/req-info.js
@@ -26,33 +26,95 @@ describe('lib/req-info.js', () => {
       });
 
       describe('with keycloak-gatekeeper headers', () => {
-        let result;
+        describe('with a single client on the old header', () => {
+          let result;
 
-        before(() => {
-          result = reqInfo({
-            headers: {
-              'x-auth-aud': 'client',
-              'x-auth-groups': 'group1,group2,group3',
-              'x-auth-roles': 'role1,role2,role3',
-              'x-auth-username': 'username'
-            }
+          before(() => {
+            result = reqInfo({
+              headers: {
+                'x-auth-aud': 'client',
+                'x-auth-groups': 'group1,group2,group3',
+                'x-auth-roles': 'role1,role2,role3',
+                'x-auth-username': 'username'
+              }
+            });
           });
+
+          it('returns a more friendly object', () => result.should.deep.equal({
+            client: 'client',
+            groups: [
+              'group1',
+              'group2',
+              'group3'
+            ],
+            roles: [
+              'role1',
+              'role2',
+              'role3'
+            ],
+            username: 'username'
+          }));
         });
 
-        it('returns a more friendly object', () => result.should.deep.equal({
-          client: 'client',
-          groups: [
-            'group1',
-            'group2',
-            'group3'
-          ],
-          roles: [
-            'role1',
-            'role2',
-            'role3'
-          ],
-          username: 'username'
-        }));
+        describe('with a single client', () => {
+          let result;
+
+          before(() => {
+            result = reqInfo({
+              headers: {
+                'x-auth-audience': 'client',
+                'x-auth-groups': 'group1,group2,group3',
+                'x-auth-roles': 'role1,role2,role3',
+                'x-auth-username': 'username'
+              }
+            });
+          });
+
+          it('returns a more friendly object', () => result.should.deep.equal({
+            client: 'client',
+            groups: [
+              'group1',
+              'group2',
+              'group3'
+            ],
+            roles: [
+              'role1',
+              'role2',
+              'role3'
+            ],
+            username: 'username'
+          }));
+        });
+
+        describe('with multiple clients', () => {
+          let result;
+
+          before(() => {
+            result = reqInfo({
+              headers: {
+                'x-auth-audience': 'client,lev-api',
+                'x-auth-groups': 'group1,group2,group3',
+                'x-auth-roles': 'role1,role2,role3',
+                'x-auth-username': 'username'
+              }
+            });
+          });
+
+          it('returns a more friendly object', () => result.should.deep.equal({
+            client: 'client',
+            groups: [
+              'group1',
+              'group2',
+              'group3'
+            ],
+            roles: [
+              'role1',
+              'role2',
+              'role3'
+            ],
+            username: 'username'
+          }));
+        });
       });
     });
   });


### PR DESCRIPTION
The way that the client is communicated to us will be changing so we
must update req-info to accommodate the new format when it comes to us.

In the future we should be able to remove support for the older
`X-Auth-Aud` header.