### PR TITLE
Bumping to lev-restify 4.0.0 - introducing a breaking change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lev-restify",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lev-restify",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
         "bunyan": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lev-restify",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Life Event Verification's Restify Server",
   "main": "src/index.js",
   "scripts": {

--- a/src/middleware/metrics.js
+++ b/src/middleware/metrics.js
@@ -3,7 +3,7 @@
 const metrics = require('../lib/metrics');
 const register = metrics.promClient.register;
 
-module.exports = (req, res, next) => {
+module.exports = async (req, res) => {
   res.set('Content-Type', register.contentType);
-  res.end(register.metrics());
+  res.end(await register.metrics());
 };

--- a/test/unit/middleware/metrics.js
+++ b/test/unit/middleware/metrics.js
@@ -4,7 +4,7 @@ const metrics = require('../../../src/middleware/metrics');
 
 describe('middleware/metrics.js', () => {
   it('is a function', () => (typeof metrics).should.equal('function'));
-  it('is a middleware', () => metrics.length.should.equal(3));
+  it('is a middleware', () => metrics.length.should.equal(2));
 
   describe('when called with three arguments', () => {
     describe('that are req, res and next objects', () => {
@@ -15,10 +15,8 @@ describe('middleware/metrics.js', () => {
         set: sinon.stub(),
         end: sinon.stub()
       };
-      const next = sinon.stub();
-
       before(() => {
-        result = metrics(req, res, next);
+        result = metrics(req, res);
       });
 
       it('sends a response', () => res.end.should.have.been.called);


### PR DESCRIPTION
the /metrics endpoint no longer returns a promise as the prom-client will now return an async function.

Previously, calling the /metrics endpoint would terminate the JavaScript runtime since prom-client introduced promise return types in v.13.0.0